### PR TITLE
Add "Jump and select" commands

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -16,8 +16,8 @@ oConfig = {
     }
 };
 
-_fStart = function( sMode ) {
-    let oInput = new InputView( atom.workspace.getActiveTextEditor(), sMode ),
+_fStart = function( sMode, bSelect ) {
+    let oInput = new InputView( atom.workspace.getActiveTextEditor(), sMode, bSelect ),
         oPanel;
 
     oPanel = atom.workspace.addBottomPanel( {
@@ -47,6 +47,15 @@ fActivate = function() {
         },
         "easy-motion-redux:words_starting": () => {
             _fStart( InputView.MODE_WORDS_STARTING );
+        },
+        "easy-motion-redux:words-select": () => {
+            _fStart( InputView.MODE_WORDS, true );
+        },
+        "easy-motion-redux:letter-select": () => {
+            _fStart( InputView.MODE_LETTER, true );
+        },
+        "easy-motion-redux:words_starting-select": () => {
+            _fStart( InputView.MODE_WORDS_STARTING, true );
         }
     } ) );
 };

--- a/lib/views/input.js
+++ b/lib/views/input.js
@@ -23,12 +23,13 @@ class InputView extends View {
         } );
     }
 
-    constructor( oRefTextEditor, sMode ) {
-        super( oRefTextEditor, sMode );
+    constructor( oRefTextEditor, sMode, bSelect ) {
+        super( oRefTextEditor, sMode, bSelect );
     }
 
-    initialize( oRefTextEditor, sMode ) {
+    initialize( oRefTextEditor, sMode, bSelect ) {
         this.sMode = sMode;
+        this.bSelect = bSelect;
         this.aPositions = [];
         this.sLetter = null;
         this.oRefTextEditor = oRefTextEditor;
@@ -146,7 +147,13 @@ class InputView extends View {
     }
 
     confirm() {
-        this.oRefTextEditor.setCursorBufferPosition( this.aPositions[ 0 ][ 0 ] );
+        let point = this.aPositions[ 0 ][ 0 ];
+        if (this.bSelect) {
+            point.column += 1; // include target letter in selection
+            this.oRefTextEditor.selectToBufferPosition( point );
+        } else {
+            this.oRefTextEditor.setCursorBufferPosition( point );
+        }
         this.goBack();
     }
 


### PR DESCRIPTION
Implements https://github.com/leny/atom-easy-motion-redux/issues/3

Example keybindings to test

``` cson
'.platform-darwin atom-text-editor':
  'cmd-:': 'easy-motion-redux:letter-select'

'atom-text-editor':
  'cmd-;': 'easy-motion-redux:letter'
  'cmd-:': 'easy-motion-redux:letter-select'
```

So if you press CMD + ;  you jump before symbol, and if you press CMD + SHIFT + ; ( witch gives cmd-: ) then you jump to position and select everything from last cursor position
