### PR TITLE
Fix exception when backspacing over search

### DIFF
--- a/lib/views/input.js
+++ b/lib/views/input.js
@@ -246,8 +246,9 @@ class InputView extends View {
         }
     }
 
-    createLetterRegExp( sLetter = "" ) {
-        return new RegExp( `${ sLetter.replace( /([\W]+)/g, "\\$1" ) }`, "gi" );
+    createLetterRegExp( sLetter ) {
+        const sSearch = ( sLetter || "" ).replace( /([\W]+)/g, "\\$1" );
+        return new RegExp( sSearch, "gi" );
     }
 
     loadPositions() {


### PR DESCRIPTION
A proper fix would involve reworking things so that searches are no longer
executed after backspacing over the entire search value. However, since
this is not done in 'startingLetterWordRegExp', I don't see much need to
do it here.

Fixes #15
