### PR TITLE
Fix exception when no matched positions

### DIFF
--- a/lib/views/input.js
+++ b/lib/views/input.js
@@ -170,7 +170,11 @@ class InputView extends View {
 
     filterPositions( sChar ) {
         this.pickPositions( sChar );
-        if ( this.aPositions.length > 1 ) {
+        const { length } = this.aPositions;
+
+        if ( length === 0 ) {
+            this.goBack();
+        } else if ( length > 1 ) {
             this.groupPositions();
         } else {
             this.confirm();


### PR DESCRIPTION
Fix issue #19

## Desc
When using
 - easy-motion-redux:words_starting
 - easy-motion-redux:letter

and type a letter match nothing, cause an error.

## Change
call goBack() when no postions to go.