### PR TITLE
Fix deprecated warnings

### DIFF
--- a/lib/views/input.js
+++ b/lib/views/input.js
@@ -82,7 +82,11 @@ class InputView extends View {
                 this.oRefTextEditor.trigger( "core:page-down" );
             }
         } ) );
-        this.subscriptions.add( this.oRefTextEditor.onDidChangeScrollTop( this.goBack.bind( this ) ) );
+
+        const goBack = this.goBack.bind( this );
+
+        this.subscriptions.add(
+            this.oRefTextEditor.element.onDidChangeScrollTop( goBack ) );
     }
 
     resetPositions() {
@@ -332,7 +336,7 @@ class InputView extends View {
             oRange = oBuffer.rangeForRow( iRow );
             let iMaxColumn = this.oRefTextEditor.getEditorWidthInChars(),
                 iCharWidth = this.oRefTextEditor.getDefaultCharWidth(),
-                iLeft = this.oRefTextEditor.getScrollLeft();
+                iLeft = this.oRefTextEditor.element.getScrollLeft();
 
             if ( iLeft === 0 ) {
                 iBeginColumn = 0;


### PR DESCRIPTION
Fix #17 (TextEditor.onDidChangeScrollTop is deprecated.)
FIx #21 (TextEditor.getScrollLeft is deprecated.) 