### PR TITLE
Make computing of lines more consistent and predictable

### DIFF
--- a/lib/views/input.js
+++ b/lib/views/input.js
@@ -52,10 +52,10 @@ class InputView extends View {
 
         switch ( this.sMode ) {
             case InputView.MODE_LETTER:
-                sPlaceholderText = "EasyMotion:Letter…";
+                sPlaceholderText = "EasyMotion:Letter";
                 break;
             case InputView.MODE_WORDS_STARTING:
-                sPlaceholderText = "EasyMotion:Words starting with letter…";
+                sPlaceholderText = "EasyMotion:Words starting with letter";
                 break;
             case InputView.MODE_WORDS:
                 sPlaceholderText = "EasyMotion:Words";

--- a/lib/views/input.js
+++ b/lib/views/input.js
@@ -368,7 +368,7 @@ class InputView extends View {
         let height = this.outerHeight(),
             pixelsPerLine = this.oRefTextEditor.getLineHeightInPixels();
 
-        return Math.ceil( height / pixelsPerLine ) * 2;
+        return Math.floor( height / pixelsPerLine );
     }
 
     notFolded( iRow ) {

--- a/lib/views/input.js
+++ b/lib/views/input.js
@@ -310,12 +310,13 @@ class InputView extends View {
     }
 
     getValidRows() {
-        let iBeginRow = this.oRefTextEditorView.getFirstVisibleScreenRow(),
-            iEndRowPadding = this.getRowPadding(),
-            iEndRow = this.oRefTextEditorView.getLastVisibleScreenRow() - iEndRowPadding,
+        const isInputAppearsBeforeThis = this.sMode === InputView.MODE_WORDS_STARTING || this.sMode === InputView.MODE_LETTER,
+            getLastVisibleScreenRow = this.oRefTextEditorView.getLastVisibleScreenRow(),
+            iBeginRow = this.oRefTextEditorView.getFirstVisibleScreenRow(),
+            iEndRow = isInputAppearsBeforeThis ? getLastVisibleScreenRow : getLastVisibleScreenRow - this.getRowPadding(),
             aResultingRows = [];
 
-        for ( let iRow of _.range( iBeginRow, iEndRow + 1 ) ) {
+        for ( let iRow of _.range( iBeginRow, iEndRow ) ) {
             if ( this.notFolded( iRow ) ) {
                 aResultingRows.push( iRow );
             }


### PR DESCRIPTION
So now it skips only necessary lines from the bottom.

![screen shot 2018-12-06 at 09 56 09](https://user-images.githubusercontent.com/974552/49566904-3dcd8300-f93d-11e8-9202-54333cc26cb6.png)

It comes from #11 and fixes it.